### PR TITLE
Fixed Error: Number can only safely store up to 53 bits 

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -22,7 +22,8 @@ export const sendAndConfirm = async (conn: web3.Connection, tx: web3.Transaction
 }
 
 export const makeDecimal = (bn: BN, decimals: number): number => {
-  return bn.toNumber() / Math.pow(10, decimals)
+  const parsedNumber = Number.parseFloat(bn.toString())
+  return parsedNumber / Math.pow(10, decimals)
 }
 
 export const makeInteger = (num: number, decimals: number): BN => {


### PR DESCRIPTION
Hi,
During test your library i found a problem when big int number larger than 53 bits (like 18,446,744,073). It will be raise error.
My pull request has fixed this problem. it's simple but effective. 
Thank for your work ! 